### PR TITLE
Use AsyncCmdlet

### DIFF
--- a/src/AsyncCmdlet.cs
+++ b/src/AsyncCmdlet.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Kubectl {
+
+    /// <summary>
+    ///		Base class for Cmdlets that run asynchronously.
+    /// </summary>
+    /// <remarks>
+    ///		Inherit from this class if your Cmdlet needs to use <c>async</c> / <c>await</c> functionality.
+    /// </remarks>
+    public abstract class AsyncCmdlet
+        : PSCmdlet, IDisposable {
+        /// <summary>
+        ///		The source for cancellation tokens that can be used to cancel the operation.
+        /// </summary>
+        readonly CancellationTokenSource _cancellationSource = new CancellationTokenSource();
+
+
+        /// <summary>
+        ///		Initialise the <see cref="AsyncCmdlet"/>.
+        /// </summary>
+        protected AsyncCmdlet() {
+        }
+
+
+        /// <summary>
+        ///		Finaliser for <see cref="AsyncCmdlet"/>.
+        /// </summary>
+        ~AsyncCmdlet() {
+            Dispose(false);
+        }
+
+
+        /// <summary>
+        ///		Dispose of resources being used by the Cmdlet.
+        /// </summary>
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+
+        /// <summary>
+        ///		Dispose of resources being used by the Cmdlet.
+        /// </summary>
+        /// <param name="disposing">
+        ///		Explicit disposal?
+        /// </param>
+        protected virtual void Dispose(bool disposing) {
+            if (disposing)
+                _cancellationSource.Dispose();
+        }
+
+        /// <summary>
+        ///		Asynchronously perform Cmdlet pre-processing.
+        /// </summary>
+        /// <returns>
+        ///		A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        protected virtual Task BeginProcessingAsync() {
+            return BeginProcessingAsync(_cancellationSource.Token);
+        }
+
+
+        /// <summary>
+        ///		Asynchronously perform Cmdlet pre-processing.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///		A <see cref="CancellationToken"/> that can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        ///		A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        protected virtual Task BeginProcessingAsync(CancellationToken cancellationToken) {
+            return Task.CompletedTask;
+        }
+
+
+        /// <summary>
+        ///		Asynchronously perform Cmdlet processing.
+        /// </summary>
+        /// <returns>
+        ///		A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        protected virtual Task ProcessRecordAsync() {
+            return ProcessRecordAsync(_cancellationSource.Token);
+        }
+
+
+        /// <summary>
+        ///		Asynchronously perform Cmdlet processing.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///		A <see cref="CancellationToken"/> that can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        ///		A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        protected virtual Task ProcessRecordAsync(CancellationToken cancellationToken) {
+            return Task.CompletedTask;
+        }
+
+
+        /// <summary>
+        ///		Asynchronously perform Cmdlet post-processing.
+        /// </summary>
+        /// <returns>
+        ///		A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        protected virtual Task EndProcessingAsync() {
+            return EndProcessingAsync(_cancellationSource.Token);
+        }
+
+
+        /// <summary>
+        ///		Asynchronously perform Cmdlet post-processing.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///		A <see cref="CancellationToken"/> that can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        ///		A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        protected virtual Task EndProcessingAsync(CancellationToken cancellationToken) {
+            return Task.CompletedTask;
+        }
+
+
+        /// <summary>
+        ///		Perform Cmdlet pre-processing.
+        /// </summary>
+        protected sealed override void BeginProcessing() {
+            ThreadAffinitiveSynchronizationContext.RunSynchronized(
+                () => BeginProcessingAsync()
+            );
+        }
+
+
+        /// <summary>
+        ///		Perform Cmdlet processing.
+        /// </summary>
+        protected sealed override void ProcessRecord() {
+            ThreadAffinitiveSynchronizationContext.RunSynchronized(
+                () => ProcessRecordAsync()
+            );
+        }
+
+
+        /// <summary>
+        ///		Perform Cmdlet post-processing.
+        /// </summary>
+        protected sealed override void EndProcessing() {
+            ThreadAffinitiveSynchronizationContext.RunSynchronized(
+                () => EndProcessingAsync()
+            );
+        }
+
+
+        /// <summary>
+        ///		Interrupt Cmdlet processing (if possible).
+        /// </summary>
+        protected sealed override void StopProcessing() {
+            _cancellationSource.Cancel();
+
+
+            base.StopProcessing();
+        }
+
+
+        /// <summary>
+        ///		Write a progress record to the output stream, and as a verbose message.
+        /// </summary>
+        /// <param name="progressRecord">
+        ///		The progress record to write.
+        /// </param>
+        protected void WriteVerboseProgress(ProgressRecord progressRecord) {
+            if (progressRecord == null)
+                throw new ArgumentNullException(nameof(progressRecord));
+
+
+            WriteProgress(progressRecord);
+            WriteVerbose(progressRecord.StatusDescription);
+        }
+
+
+        /// <summary>
+        ///		Write a progress record to the output stream, and as a verbose message.
+        /// </summary>
+        /// <param name="progressRecord">
+        ///		The progress record to write.
+        /// </param>
+        /// <param name="messageOrFormat">
+        ///		The message or message-format specifier.
+        /// </param>
+        /// <param name="formatArguments">
+        ///		Optional format arguments.
+        /// </param>
+        protected void WriteVerboseProgress(ProgressRecord progressRecord, string messageOrFormat, params object[] formatArguments) {
+            if (progressRecord == null)
+                throw new ArgumentNullException(nameof(progressRecord));
+
+
+            if (String.IsNullOrWhiteSpace(messageOrFormat))
+                throw new ArgumentException("Argument cannot be null, empty, or composed entirely of whitespace: 'messageOrFormat'.", nameof(messageOrFormat));
+
+
+            if (formatArguments == null)
+                throw new ArgumentNullException(nameof(formatArguments));
+
+
+            progressRecord.StatusDescription = String.Format(messageOrFormat, formatArguments);
+            WriteVerboseProgress(progressRecord);
+        }
+
+
+        /// <summary>
+        ///		Write a completed progress record to the output stream.
+        /// </summary>
+        /// <param name="progressRecord">
+        ///		The progress record to complete.
+        /// </param>
+        /// <param name="completionMessageOrFormat">
+        ///		The completion message or message-format specifier.
+        /// </param>
+        /// <param name="formatArguments">
+        ///		Optional format arguments.
+        /// </param>
+        protected void WriteProgressCompletion(ProgressRecord progressRecord, string completionMessageOrFormat, params object[] formatArguments) {
+            if (progressRecord == null)
+                throw new ArgumentNullException(nameof(progressRecord));
+
+
+            if (String.IsNullOrWhiteSpace(completionMessageOrFormat))
+                throw new ArgumentException("Argument cannot be null, empty, or composed entirely of whitespace: 'completionMessageOrFormat'.", nameof(completionMessageOrFormat));
+
+
+            if (formatArguments == null)
+                throw new ArgumentNullException(nameof(formatArguments));
+
+
+            progressRecord.StatusDescription = String.Format(completionMessageOrFormat, formatArguments);
+            progressRecord.PercentComplete = 100;
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            WriteProgress(progressRecord);
+            WriteVerbose(progressRecord.StatusDescription);
+        }
+    }
+}

--- a/src/GetKubePodCmdlet.cs
+++ b/src/GetKubePodCmdlet.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
 using KubeClient;
 using KubeClient.Models;
 using KubeClient.ResourceClients;
@@ -11,7 +13,7 @@ namespace Kubectl {
     [OutputType(new[] { typeof(PodV1) })]
     public sealed class GetKubePodCmdlet : KubeCmdlet {
         [Parameter()]
-        public string Namespace { get; set; } = "default";
+        public string Namespace { get; set; }
 
         [Parameter()]
         public string LabelSelector { get; set; }
@@ -19,21 +21,21 @@ namespace Kubectl {
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         public string Name { get; set; }
 
-        protected override void ProcessRecord() {
-            base.ProcessRecord();
+        protected override async Task ProcessRecordAsync(CancellationToken cancellationToken) {
+            await base.ProcessRecordAsync(cancellationToken);
             if (String.IsNullOrEmpty(Name)) {
-                PodListV1 podList = client.PodsV1().List(
+                PodListV1 podList = await client.PodsV1().List(
                     kubeNamespace: Namespace,
                     labelSelector: LabelSelector,
-                    cancellationToken: CancellationToken
-                ).GetAwaiter().GetResult();
+                    cancellationToken: cancellationToken
+                );
                 WriteObject(podList);
             } else {
-                PodV1 pod = client.PodsV1().Get(
+                PodV1 pod = await client.PodsV1().Get(
                     name: Name,
                     kubeNamespace: Namespace,
-                    cancellationToken: CancellationToken
-                ).GetAwaiter().GetResult();
+                    cancellationToken: cancellationToken
+                );
                 WriteObject(pod);
             }
         }

--- a/src/ThreadAffinitiveSynchronizationContext.cs
+++ b/src/ThreadAffinitiveSynchronizationContext.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Kubectl {
+    /// <summary>
+    ///		A synchronisation context that runs all calls scheduled on it (via <see cref="SynchronizationContext.Post"/>) on a single thread.
+    /// </summary>
+    /// <remarks>
+    ///		With thanks to Stephen Toub.
+    /// </remarks>
+    public sealed class ThreadAffinitiveSynchronizationContext
+        : SynchronizationContext, IDisposable {
+        /// <summary>
+        ///		A blocking collection (effectively a queue) of work items to execute, consisting of callback delegates and their callback state (if any).
+        /// </summary>
+        BlockingCollection<KeyValuePair<SendOrPostCallback, object>> _workItemQueue = new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
+
+
+        /// <summary>
+        ///		Create a new thread-affinitive synchronisation context.
+        /// </summary>
+        ThreadAffinitiveSynchronizationContext() {
+        }
+
+
+        /// <summary>
+        ///		Dispose of resources being used by the synchronisation context.
+        /// </summary>
+        void IDisposable.Dispose() {
+            if (_workItemQueue != null) {
+                _workItemQueue.Dispose();
+                _workItemQueue = null;
+            }
+        }
+
+
+        /// <summary>
+        ///		Check if the synchronisation context has been disposed.
+        /// </summary>
+        void CheckDisposed() {
+            if (_workItemQueue == null)
+                throw new ObjectDisposedException(GetType().Name);
+        }
+
+
+        /// <summary>
+        ///		Run the message pump for the callback queue on the current thread.
+        /// </summary>
+        void RunMessagePump() {
+            CheckDisposed();
+
+
+            KeyValuePair<SendOrPostCallback, object> workItem;
+            while (_workItemQueue.TryTake(out workItem, Timeout.InfiniteTimeSpan)) {
+                workItem.Key(workItem.Value);
+
+
+                // Has the synchronisation context been disposed?
+                if (_workItemQueue == null)
+                    break;
+            }
+        }
+
+
+        /// <summary>
+        ///		Terminate the message pump once all callbacks have completed.
+        /// </summary>
+        void TerminateMessagePump() {
+            CheckDisposed();
+
+
+            _workItemQueue.CompleteAdding();
+        }
+
+
+        /// <summary>
+        ///		Dispatch an asynchronous message to the synchronization context.
+        /// </summary>
+        /// <param name="callback">
+        ///		The <see cref="SendOrPostCallback"/> delegate to call in the synchronisation context.
+        /// </param>
+        /// <param name="callbackState">
+        ///		Optional state data passed to the callback.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///		The message pump has already been started, and then terminated by calling <see cref="TerminateMessagePump"/>.
+        /// </exception>
+        public override void Post(SendOrPostCallback callback, object callbackState) {
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+
+            CheckDisposed();
+
+
+            try {
+                _workItemQueue.Add(
+                    new KeyValuePair<SendOrPostCallback, object>(
+                        key: callback,
+                        value: callbackState
+                    )
+                );
+            } catch (InvalidOperationException eMessagePumpAlreadyTerminated) {
+                throw new InvalidOperationException(
+                    "Cannot enqueue the specified callback because the synchronisation context's message pump has already been terminated.",
+                    eMessagePumpAlreadyTerminated
+                    );
+            }
+        }
+
+
+        /// <summary>
+        ///		Run an asynchronous operation using the current thread as its synchronisation context.
+        /// </summary>
+        /// <param name="asyncOperation">
+        ///		A <see cref="Func{TResult}"/> delegate representing the asynchronous operation to run.
+        /// </param>
+        public static void RunSynchronized(Func<Task> asyncOperation) {
+            if (asyncOperation == null)
+                throw new ArgumentNullException(nameof(asyncOperation));
+
+
+            SynchronizationContext savedContext = Current;
+            try {
+                using (ThreadAffinitiveSynchronizationContext synchronizationContext = new ThreadAffinitiveSynchronizationContext()) {
+                    SetSynchronizationContext(synchronizationContext);
+
+
+                    Task rootOperationTask = asyncOperation();
+                    if (rootOperationTask == null)
+                        throw new InvalidOperationException("The asynchronous operation delegate cannot return null.");
+
+
+                    rootOperationTask.ContinueWith(
+                        operationTask =>
+                            synchronizationContext.TerminateMessagePump(),
+                        scheduler:
+                            TaskScheduler.Default
+                    );
+
+
+                    synchronizationContext.RunMessagePump();
+
+
+                    try {
+                        rootOperationTask
+                            .GetAwaiter()
+                            .GetResult();
+                    } catch (AggregateException eWaitForTask) // The TPL will almost always wrap an AggregateException around any exception thrown by the async operation.
+                      {
+                        // Is this just a wrapped exception?
+                        AggregateException flattenedAggregate = eWaitForTask.Flatten();
+                        if (flattenedAggregate.InnerExceptions.Count != 1)
+                            throw; // Nope, genuine aggregate.
+
+
+                        // Yep, so rethrow (preserving original stack-trace).
+                        ExceptionDispatchInfo
+                            .Capture(
+                                flattenedAggregate
+                                    .InnerExceptions[0]
+                            )
+                            .Throw();
+                    }
+                }
+            } finally {
+                SetSynchronizationContext(savedContext);
+            }
+        }
+
+
+        /// <summary>
+        ///		Run an asynchronous operation using the current thread as its synchronisation context.
+        /// </summary>
+        /// <typeparam name="TResult">
+        ///		The operation result type.
+        /// </typeparam>
+        /// <param name="asyncOperation">
+        ///		A <see cref="Func{TResult}"/> delegate representing the asynchronous operation to run.
+        /// </param>
+        /// <returns>
+        ///		The operation result.
+        /// </returns>
+        public static TResult RunSynchronized<TResult>(Func<Task<TResult>> asyncOperation) {
+            if (asyncOperation == null)
+                throw new ArgumentNullException(nameof(asyncOperation));
+
+
+            SynchronizationContext savedContext = Current;
+            try {
+                using (ThreadAffinitiveSynchronizationContext synchronizationContext = new ThreadAffinitiveSynchronizationContext()) {
+                    SetSynchronizationContext(synchronizationContext);
+
+
+                    Task<TResult> rootOperationTask = asyncOperation();
+                    if (rootOperationTask == null)
+                        throw new InvalidOperationException("The asynchronous operation delegate cannot return null.");
+
+
+                    rootOperationTask.ContinueWith(
+                        operationTask =>
+                            synchronizationContext.TerminateMessagePump(),
+                        scheduler:
+                            TaskScheduler.Default
+                    );
+
+
+                    synchronizationContext.RunMessagePump();
+
+
+                    try {
+                        return
+                            rootOperationTask
+                                .GetAwaiter()
+                                .GetResult();
+                    } catch (AggregateException eWaitForTask) // The TPL will almost always wrap an AggregateException around any exception thrown by the async operation.
+                      {
+                        // Is this just a wrapped exception?
+                        AggregateException flattenedAggregate = eWaitForTask.Flatten();
+                        if (flattenedAggregate.InnerExceptions.Count != 1)
+                            throw; // Nope, genuine aggregate.
+
+
+                        // Yep, so rethrow (preserving original stack-trace).
+                        ExceptionDispatchInfo
+                            .Capture(
+                                flattenedAggregate
+                                    .InnerExceptions[0]
+                            )
+                            .Throw();
+
+
+                        throw; // Never reached.
+                    }
+                }
+            } finally {
+                SetSynchronizationContext(savedContext);
+            }
+        }
+    }
+}


### PR DESCRIPTION
@tintoy I followed your suggestion of using `AsyncCmdlet` and it seems to work fine. Before, I could not cancel `Get-KubeLog -Follow` with <kbd>ctrl</kbd>+<kbd>C</kbd>, but now I can. However, it always throws this exception that crashes the PowerShell process:
```
^C

An error has occurred that was not properly handled. Additional information is shown below. The PowerShell process will exit.

Unhandled Exception: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'ThreadAffinitiveSynchronizationContext'.
   at Kubectl.ThreadAffinitiveSynchronizationContext.CheckDisposed() in /Users/felix/src/github.com/felixfbecker/PSKubectl/src/ThreadAffinitiveSynchronizationContext.cs:line 48
   at Kubectl.ThreadAffinitiveSynchronizationContext.Post(SendOrPostCallback callback, Object callbackState) in /Users/felix/src/github.com/felixfbecker/PSKubectl/src/ThreadAffinitiveSynchronizationContext.cs:line 98
   at System.Threading.Tasks.AwaitTaskContinuation.RunCallback(ContextCallback callback, Object state, Task& currentTask)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

Any idea why?