### PR TITLE
Target .Net Standard 2.0

### DIFF
--- a/src/Cmdlets/CompareKubeResourceCmdlet.cs
+++ b/src/Cmdlets/CompareKubeResourceCmdlet.cs
@@ -49,8 +49,7 @@ namespace Kubectl.Cmdlets {
             string apiGroupVersion = (string)Original.ApiVersion;
             string apiVersion = apiGroupVersion.Split('/').Last();
             string kind = (string)Original.Kind;
-            Type type = ModelTypes.GetValueOrDefault((kind, apiVersion));
-            if (type == null) {
+            if (!ModelTypes.TryGetValue((kind, apiVersion), out Type type)) {
                 WriteError(new ErrorRecord(new Exception($"Unknown (kind: {kind}, apiVersion: {apiVersion}). {ModelTypes.Count} Known:\n{String.Join("\n", ModelTypes.Keys)}"), null, ErrorCategory.InvalidData, null));
                 return;
             }

--- a/src/Cmdlets/UseKubeContextCmdlet.cs
+++ b/src/Cmdlets/UseKubeContextCmdlet.cs
@@ -25,7 +25,9 @@ namespace Kubectl.Cmdlets {
             Serializer serializer = new SerializerBuilder().Build();
             string yaml = serializer.Serialize(config);
             if (ShouldProcess(configPath, "update")) {
-                await File.WriteAllTextAsync(configPath, yaml); // Do not pass cancellationToken to not corrupt config file
+                using (var streamWriter = new StreamWriter(configPath)) {
+                    await streamWriter.WriteAsync(yaml); // Do not pass cancellationToken to not corrupt config file
+                }
             }
         }
     }

--- a/src/KubeResourceComparer.cs
+++ b/src/KubeResourceComparer.cs
@@ -239,8 +239,8 @@ namespace Kubectl {
                     } else {
                         logger.LogTrace("List is unordered set");
                         // Lists are to be treated like unordered sets
-                        HashSet<object> originalSet = originalEnumerable.ToHashSet();
-                        HashSet<object> modifiedSet = modifiedEnumerable.ToHashSet();
+                        var originalSet = new HashSet<object>(originalEnumerable);
+                        var modifiedSet = new HashSet<object>(modifiedEnumerable);
                         // The index to adress the element on the server after applying every operation in the patch so far.
                         int index = 0;
                         foreach (var originalElement in originalEnumerable) {

--- a/src/KubeYamlDeserializer.cs
+++ b/src/KubeYamlDeserializer.cs
@@ -31,8 +31,7 @@ namespace Kubectl {
             string apiGroupVersion = (string)dict["apiVersion"];
             string apiVersion = apiGroupVersion.Split('/').Last();
             logger.LogDebug($"apiVersion {apiVersion}");
-            Type type = modelTypes.GetValueOrDefault((kind, apiVersion));
-            if (type == null) {
+            if (!modelTypes.TryGetValue((kind, apiVersion), out Type type)) {
                 throw new Exception($"Unknown (kind: {kind}, apiVersion: {apiVersion}). {modelTypes.Count} Known:\n{String.Join("\n", modelTypes.Keys)}");
             }
             return toPSObject(dict, type);

--- a/src/PSKubectl.csproj
+++ b/src/PSKubectl.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <!-- <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> -->
     </PropertyGroup>
     <ItemGroup>

--- a/src/SetKubeConfigCmdlet.cs
+++ b/src/SetKubeConfigCmdlet.cs
@@ -21,7 +21,9 @@ namespace Kubectl {
             string yaml = serializer.Serialize(Config);
             string configPath = K8sConfig.Locate();
             if (ShouldProcess(configPath, "update")) {
-                await File.WriteAllTextAsync(configPath, yaml); // Do not pass cancellationToken to not corrupt config file
+                using (var streamWriter = new StreamWriter(configPath)) {
+                    await streamWriter.WriteAsync(yaml); // Do not pass cancellationToken to not corrupt config file
+                }
             }
         }
     }


### PR DESCRIPTION
API's are nearly the same in terms of behaviour, the only lost functionality to cancel the async reading of the file.
This also highly reduced the size of the module from around 160 MB to 10MB
In practice one could even look at it in detail and exclude most DLLs (as PowerShell provides most of them therefore only DLLs from the project itself and it's NuGet packages are technically needed.