### PR TITLE
Use dotnet build to reduce the number of necessary DLLS

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -12,7 +12,9 @@ try {
         $options += '--no-restore'
     }
     dotnet build --output ../PSKubectl/Assemblies --configuration $Configuration @options
-    Remove-Item  ../PSKubectl/Assemblies/Newtonsoft.Json.dll # PowerShell Core ships with this DLL already and cannot load 2 DLLs of the same type anyway
+    # PowerShell Core ships with some DLLs already and cannot load 2 DLLs of the same type anyway
+    Remove-Item  ../PSKubectl/Assemblies/Newtonsoft.Json.dll
+    Remove-Item  ../PSKubectl/Assemblies/Microsoft.CSharp.dll
     if ($LASTEXITCODE -ne 0) {
         throw "Build failed"
     }

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,7 @@ try {
     if ($NoRestore) {
         $options += '--no-restore'
     }
-    dotnet publish -o ../PSKubectl/Assemblies -c $Configuration @options
+    dotnet build --output ../PSKubectl/Assemblies -c $Configuration @options
     if ($LASTEXITCODE -ne 0) {
         throw "Build failed"
     }

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,8 @@ try {
     if ($NoRestore) {
         $options += '--no-restore'
     }
-    dotnet build --output ../PSKubectl/Assemblies -c $Configuration @options
+    dotnet build --output ../PSKubectl/Assemblies --configuration $Configuration @options
+    Remove-Item  ../PSKubectl/Assemblies/Newtonsoft.Json.dll # PowerShell Core ships with this DLL already and cannot load 2 DLLs of the same type anyway
     if ($LASTEXITCODE -ne 0) {
         throw "Build failed"
     }

--- a/src/PSKubectl.csproj
+++ b/src/PSKubectl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <!-- <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> -->
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>        <!-- Workaround for NuGet bug to make dotnet build copy NuGet assemblies into bin folder as well: https://github.com/dotnet/sdk/issues/747#issuecomment-419497340 -->
     </PropertyGroup>
     <ItemGroup>
         <!-- <ProjectReference Include="../../../tintoy/dotnet-kube-client/src/KubeClient/KubeClient.csproj" /> -->


### PR DESCRIPTION
Had to use workaround of NuGet bug where `dotnet build` does not copy the NuGet DLLs into the bin folder by default.
This reduces the size of the module from 9.7 MB to to 6.02MB, which is a further reduction of 38%. This is possible and relatively safe because PowerShell ships nearly the complete .Net Core Runtime already and the passing tests show this. What we need are the DLLs from the 3 NuGet packages that you reference.
I also delete the `Newtonsoft.Json` DLL as PS ships with that as well aready and currently cannot load more than 1 instance of 1DLL anyway. You want to rather rely on the version loaded that is shipped by the specific version of PowerShell rather than having different behaviour depending on which version of Newtonsoft gets loaded first (which would depend on the cmdlet execution order)