### PR TITLE
feat: add support for Namespace Objects

### DIFF
--- a/src/Cmdlets/GetKubeDeploymentCmdlet.cs
+++ b/src/Cmdlets/GetKubeDeploymentCmdlet.cs
@@ -13,30 +13,47 @@ namespace Kubectl.Cmdlets {
     [Cmdlet(VerbsCommon.Get, "KubeDeployment")]
     [OutputType(new[] { typeof(DeploymentV1) })]
     public sealed class GetKubeDeploymentCmdlet : KubeApiCmdlet {
+        private const string DefaultParamSet = "DefaultParamSet";
+        private const string NamespaceObjectSet = "NamespaceObjectSet";
+
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [Alias("Ns")]
         public string Namespace { get; set; } = "default";
 
+        [Parameter(
+            Mandatory = true,
+            Position = 0,
+            ParameterSetName = NamespaceObjectSet,
+            ValueFromPipeline = true)]
+        [ValidateNotNull()]
+        public NamespaceV1 NamespaceObject { get; set; }
+
         [Parameter()]
         public string LabelSelector { get; set; }
 
-        [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(
+            Position = 0,
+            ParameterSetName = DefaultParamSet,
+            ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [SupportsWildcards()]
         public string Name { get; set; }
 
         protected override async Task ProcessRecordAsync(CancellationToken cancellationToken) {
             await base.ProcessRecordAsync(cancellationToken);
+
+            var _namespace = NamespaceObject?.Metadata.Name ?? Namespace;
+
             IEnumerable<DeploymentV1> deploymentList;
             if (String.IsNullOrEmpty(Name) || WildcardPattern.ContainsWildcardCharacters(Name)) {
                 deploymentList = await client.DeploymentsV1().List(
-                    kubeNamespace: Namespace,
+                    kubeNamespace: _namespace,
                     labelSelector: LabelSelector,
                     cancellationToken: cancellationToken
                 );
             } else {
                 DeploymentV1 deployment = await client.DeploymentsV1().Get(
                     name: Name,
-                    kubeNamespace: Namespace,
+                    kubeNamespace: _namespace,
                     cancellationToken: cancellationToken
                 );
                 deploymentList = new[] { deployment };

--- a/src/Cmdlets/GetKubeNamespaceCmdlet.cs
+++ b/src/Cmdlets/GetKubeNamespaceCmdlet.cs
@@ -11,9 +11,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Kubectl.Cmdlets {
     [Cmdlet(VerbsCommon.Get, "KubeNamespace")]
-    [OutputType(new[] { typeof(PodV1) })]
+    [OutputType(new[] { typeof(NamespaceV1) })]
     public sealed class GetKubeNamespaceCmdlet : KubeApiCmdlet {
-
         [Parameter()]
         public string LabelSelector { get; set; }
 

--- a/src/Cmdlets/GetKubePodCmdlet.cs
+++ b/src/Cmdlets/GetKubePodCmdlet.cs
@@ -13,30 +13,47 @@ namespace Kubectl.Cmdlets {
     [Cmdlet(VerbsCommon.Get, "KubePod")]
     [OutputType(new[] { typeof(PodV1) })]
     public sealed class GetKubePodCmdlet : KubeApiCmdlet {
+        private const string DefaultParamSet = "DefaultParamSet";
+        private const string NamespaceObjectSet = "NamespaceObjectSet";
+
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [Alias("Ns")]
         public string Namespace { get; set; } = "default";
 
+        [Parameter(
+            Mandatory = true,
+            Position = 0,
+            ParameterSetName = NamespaceObjectSet,
+            ValueFromPipeline = true)]
+        [ValidateNotNull()]
+        public NamespaceV1 NamespaceObject { get; set; }
+
         [Parameter()]
         public string LabelSelector { get; set; }
 
-        [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(
+            Position = 0,
+            ParameterSetName = DefaultParamSet,
+            ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [SupportsWildcards()]
         public string Name { get; set; }
 
         protected override async Task ProcessRecordAsync(CancellationToken cancellationToken) {
             await base.ProcessRecordAsync(cancellationToken);
+
+            var _namespace = NamespaceObject?.Metadata.Name ?? Namespace;
+
             IEnumerable<PodV1> podList;
             if (String.IsNullOrEmpty(Name) || WildcardPattern.ContainsWildcardCharacters(Name)) {
                 podList = await client.PodsV1().List(
-                    kubeNamespace: Namespace,
+                    kubeNamespace: _namespace,
                     labelSelector: LabelSelector,
                     cancellationToken: cancellationToken
                 );
             } else {
                 PodV1 pod = await client.PodsV1().Get(
                     name: Name,
-                    kubeNamespace: Namespace,
+                    kubeNamespace: _namespace,
                     cancellationToken: cancellationToken
                 );
                 podList = new[] { pod };
@@ -45,6 +62,7 @@ namespace Kubectl.Cmdlets {
                 var pattern = new WildcardPattern(Name);
                 podList = podList.Where(pod => pattern.IsMatch(pod.Metadata.Name));
             }
+
             WriteObject(podList, true);
         }
     }

--- a/src/Cmdlets/RemoveKubeResourceCmdlet.cs
+++ b/src/Cmdlets/RemoveKubeResourceCmdlet.cs
@@ -19,7 +19,7 @@ namespace Kubectl.Cmdlets {
         private const string ResourceObjectSet = "ResourceObjectSet";
 
         [Alias("Ns")]
-        [Parameter(ParameterSetName = "Parameters")]
+        [Parameter(ParameterSetName = DefaultParamSet)]
         public string Namespace { get; set; }
 
         [Parameter(


### PR DESCRIPTION
This adds the ability for the commands that take a namespace to take a namespace object. This allows for `Get-KubeNamespace | Get-KubePod` to be used and other situations.

While we are here, clean up the naming convention and leave an alias behind to prevent backwards compatibility problems. Additionally, use const strings for ParameterSetNames to give us a compiler warning if there is a typo.

These changes try to follow how Azure PowerShell is structured.

I should have put this work into a feature branch, but I'll just force push my master branch if this gets merged in and remember to do that in the future.